### PR TITLE
Set tab label to title attribute

### DIFF
--- a/src/web/components/global-nav/container/sub-nav/tabs/tab/tab.js
+++ b/src/web/components/global-nav/container/sub-nav/tabs/tab/tab.js
@@ -23,7 +23,7 @@ class Tab extends Core {
 
     setLabel(label) {
         this.el.textContent = label;
-        this.el.setAttr('label', label);
+        this.el.setAttribute("title", label);
     }
 
     activate() {


### PR DESCRIPTION
Corrects a typo/bug. Setting label after initialization caused an error because `setAttr` is not a function.