### PR TITLE
Run http server and gemini in a single command

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -35,7 +35,5 @@ which will trigger our build script to create an updated release file in [src/we
 ## Running visual regression tests
 
 - Make sure `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` are set in `/.env`.
-- Install http-server packcage via `npm install http-server -g`
-- In the root directory of the project run command `http-server` from command line
-- In separate command line windo run the tests and generate a report: `$ npm run gemini-report`
+- Run the gemini tests and generate a report: `$ npm run gemini-report`
 - View the report: `$ open ./gemini-report/index.html`

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "webpack",
     "watch": "webpack --watch",
     "build-icons": "node src/web/basics/icons/build/build.js",
-    "gemini": "gemini test gemini/*",
-    "gemini-report": "gemini test gemini/* --reporter html --reporter flat",
-    "gemini-update": "gemini update gemini/*"
+    "gemini": "concurrently 'http-server' 'gemini test gemini/*' --kill-others",
+    "gemini-report": "concurrently 'http-server' 'gemini test gemini/* --reporter html --reporter flat' --kill-others",
+    "gemini-update": "concurrently 'http-server' 'gemini update gemini/*' --kill-others"
   },
   "repository": {
     "type": "git",
@@ -23,6 +23,7 @@
     "babel-loader": "^6.3.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-es2015": "^6.22.0",
+    "concurrently": "^3.4.0",
     "css-loader": "^0.26.1",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "gemini": "^4.18.1",


### PR DESCRIPTION
Use `concurrently` package to startup the http server, run gemini tests, and shut them both down when tests have finished.