### PR TITLE
regenerate files and gitignore nohup.out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,8 @@ jspm_packages
 # Gemini Report
 /gemini-report
 
+# Files created by CircleCI
+nohup.out
+
 # Environment Variables
 .env

--- a/index.html
+++ b/index.html
@@ -8,9 +8,13 @@
   <h1>HIG Example Tests</h1>
   <div>
     <ol>
+      <li><a href="/src/web/basics/button/tests/gemini-button.html">gemini-button.html</a></li>
       <li><a href="/src/web/basics/button/tests/tests-button.html">tests-button.html</a></li>
+      <li><a href="/src/web/basics/flyout/tests/gemini-flyout.html">gemini-flyout.html</a></li>
+      <li><a href="/src/web/basics/flyout/tests/test-flyout.html">flyout.html</a></li>
       <li><a href="/src/web/components/global-nav/tests/gemini-global-nav.html">gemini-global-nav.html</a></li>
       <li><a href="/src/web/components/global-nav/tests/tests-global-nav.html">tests-global-nav.html</a></li>
+      <li><a href="/src/web/components/global-nav/top-nav/profile/tests/gemini-profile.html">gemini-profile.html</a></li>
     </ol>
   </div>
 </body>


### PR DESCRIPTION
### Problem
CircleCI generates a nohup.out file which is causing the diff check portion of the deploy script to fail, and thence failing CI.  

### Solution
add nohup.out to .gitignore.
Also, index.html appears to be out of date.
