### PR TITLE
exclude gemini, prefix href with /hig

### DIFF
--- a/deploy/compile-gh-pages.js
+++ b/deploy/compile-gh-pages.js
@@ -16,7 +16,7 @@ const mustache = require('mustache');
 const thisDir = __dirname;
 const rootDir = path.resolve(__dirname + "/../");
 
-const testsGlob = rootDir + "/src/**/tests/*.html"
+const testsGlob = rootDir + "/src/**/tests/test*.html"
 const templatePath = thisDir + "/index.template.html"
 
 const indexMustacheTemplate = fs.readFileSync(templatePath, {encoding: 'utf8'});
@@ -32,11 +32,9 @@ glob(testsGlob, (er, files) => {
   var testList = { testLinks: [] };
 
   files.forEach(function(filePath) {
-    var newFilePath = "/" + path.relative(rootDir, filePath);
+    var newFilePath = "/hig/" + path.relative(rootDir, filePath);
     var title = path.parse(filePath).base.replace("test-", "");
-    testList.testLinks.push(
-      { href: newFilePath, title: title }
-    )
+    testList.testLinks.push({ href: newFilePath, title: title });
   });
 
   const rendered = mustache.render(indexMustacheTemplate, testList);

--- a/index.html
+++ b/index.html
@@ -8,14 +8,9 @@
   <h1>HIG Example Tests</h1>
   <div>
     <ol>
-      <li><a href="/src/web/basics/button/tests/gemini-button.html">gemini-button.html</a></li>
-      <li><a href="/src/web/basics/button/tests/tests-button.html">tests-button.html</a></li>
-      <li><a href="/src/web/basics/flyout/tests/gemini-flyout.html">gemini-flyout.html</a></li>
-      <li><a href="/src/web/basics/flyout/tests/test-flyout.html">flyout.html</a></li>
-      <li><a href="/src/web/components/global-nav/side-nav/tests/gemini-side-nav.html">gemini-side-nav.html</a></li>
-      <li><a href="/src/web/components/global-nav/tests/gemini-global-nav.html">gemini-global-nav.html</a></li>
-      <li><a href="/src/web/components/global-nav/tests/tests-global-nav.html">tests-global-nav.html</a></li>
-      <li><a href="/src/web/components/global-nav/top-nav/profile/tests/gemini-profile.html">gemini-profile.html</a></li>
+      <li><a href="/hig/src/web/basics/button/tests/tests-button.html">tests-button.html</a></li>
+      <li><a href="/hig/src/web/basics/flyout/tests/test-flyout.html">flyout.html</a></li>
+      <li><a href="/hig/src/web/components/global-nav/tests/tests-global-nav.html">tests-global-nav.html</a></li>
     </ol>
   </div>
 </body>


### PR DESCRIPTION
### Problem (see #52 )
In  my enthusiasm for viewing the index.html file locally with http-server, I forgot that github pages requires you to prefix the URL to source files with the project name.

Also, gemini files should be excluded from the test file glob pattern. 

### Solution
Although viewing the static files works fine locally, because of the prefix to the path on index.html, This breaks the links locally with http-server.  But it should work on github  #pages.

It also matches only on files w/ path matching `/src/**/tests/test*.html` .
